### PR TITLE
Indicate active env name in spawned environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ vaulted -n env_name command arg1 arg2
 ```sh
 vaulted -n env_name -i
 ```
+
+# Environment Self-Awareness
+
+Vaulted will set an environment variable in spawned environments for commands or interactive shells to allow the spawned process to be aware that it is within a Vaulted-spawned environment. This is particularly useful if you would like to indicate such status in your shell prompt.
+
+By default this environment variable is named `VAULTED_ACTIVE_ENV`, but another name may be specified with the `-E` option. Or set the value to an empty string (`-E ''`) to prevent Vaulted from adding the extra environment variable.

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ var (
 
 	charDevice bool
 
+	activeEnvVarName string
+
 	// vault
 	vaultKey  []byte
 	vaultData []byte
@@ -64,6 +66,7 @@ func init() {
 	flag.BoolVar(&interactiveAdd, "a", false, "add to environment interactively")
 	flag.BoolVar(&deleteEnvironment, "D", false, "delete environment from vault")
 	flag.BoolVar(&interactiveShell, "i", false, "spawn a new shell populated with the environment")
+	flag.StringVar(&activeEnvVarName, "E", "VAULTED_ACTIVE_ENV", "env var name to set in a spawned environment")
 	flag.Parse()
 
 	// figure out which mode the user wants
@@ -259,6 +262,11 @@ func spawnEnvironmentMode() {
 	vars := ParseEnviron(os.Environ())
 	for key, val := range env.Vars {
 		vars[key] = val
+	}
+
+	// indicate the name of the Vaulted environment
+	if activeEnvVarName != "" {
+		vars[activeEnvVarName] = environment
 	}
 
 	// locate the executable


### PR DESCRIPTION
The idea here is to set an environment variable in the spawned command or interactive shell so that the command or shell can be aware and/or indicate its status. In particular I'm interested in being able to flag my shell environment to indicate that 1) I'm in a vaulted interactive shell, and shouldn't leave it open beyond its immediate purpose, and 2) which vaulted environment I'm in, so that I'm always aware of what  capabilities I may have because of the environment variables.

This PR sets the default environment variable to be appended to the spawned environment to `VAULTED_ACTIVE_ENV`, but makes this configurable via `-E`. It's also possible to disable the functionality by passing an empty string as the value eg, `-E ''`.

If you'd prefer it to default to empty string/no var instead, let me know, and I can swap it around easily enough.