### PR TITLE
Indicate env name in spawned environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ vaulted -n env_name command arg1 arg2
 ```sh
 vaulted -n env_name -i
 ```
+
+# Environment Self-Awareness
+
+Vaulted will set an environment variable `VAULTED_ENV` in spawned environments for commands or interactive shells to allow the spawned process to be aware that it is within a Vaulted-spawned environment. This is particularly useful if you would like to indicate such status in your shell prompt.

--- a/main.go
+++ b/main.go
@@ -261,6 +261,9 @@ func spawnEnvironmentMode() {
 		vars[key] = val
 	}
 
+	// indicate the name of the Vaulted environment
+	vars["VAULTED_ENV"] = environment
+
 	// locate the executable
 	fullpath, err := exec.LookPath(spawnArgs[0])
 	if err != nil {


### PR DESCRIPTION
Ensure `VAULTED_ENV` is set to the correct environment name in spawned process environments to allow for interactive feedback or other self-awareness.