### PR TITLE
Use $VAULTED_DEFAULT_ENV as the default environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 )
 
 func init() {
-	environment = os.Getenv("VAULTED_ENV")
+	environment = os.Getenv("VAULTED_DEFAULT_ENV")
 
 	u, err := user.Current()
 	if err != nil {


### PR DESCRIPTION
Avoids name clashes with using VAULTED_ENV to indicate to spawned
commands what vault is currently in use.