### PR TITLE
Change environment duration to time.Time

### DIFF
--- a/lib/environment.go
+++ b/lib/environment.go
@@ -14,9 +14,9 @@ import (
 )
 
 type Environment struct {
-	Expiration int64             `json:"expiration"`
-	Vars       map[string]string `json:"vars"`
+	Expiration time.Time         `json:"expiration"`
 	AWSCreds   *AWSCredentials   `json:"aws_creds,omitempty"`
+	Vars       map[string]string `json:"vars,omitempty"`
 	SSHKeys    map[string]string `json:"ssh_keys,omitempty"`
 }
 
@@ -105,7 +105,7 @@ func (e *Environment) startProxyKeyring() (string, error) {
 
 	// load ssh keys
 	for comment, key := range e.SSHKeys {
-		timeRemaining := time.Unix(e.Expiration, 0).Sub(time.Now())
+		timeRemaining := e.Expiration.Sub(time.Now())
 		addedKey := agent.AddedKey{
 			Comment:      comment,
 			LifetimeSecs: uint32(timeRemaining.Seconds()),

--- a/lib/vault.go
+++ b/lib/vault.go
@@ -25,10 +25,10 @@ var (
 )
 
 type Vault struct {
-	Vars     map[string]string `json:"vars"`
-	AWSKey   *AWSKey           `json:"aws_key,omitempty"`
-	SSHKeys  map[string]string `json:"ssh_keys,omitempty"`
 	Duration time.Duration     `json:"duration,omitempty"`
+	AWSKey   *AWSKey           `json:"aws_key,omitempty"`
+	Vars     map[string]string `json:"vars,omitempty"`
+	SSHKeys  map[string]string `json:"ssh_keys,omitempty"`
 }
 
 type AWSCredentials struct {
@@ -54,7 +54,7 @@ func (v *Vault) CreateEnvironment(extraVars map[string]string) (*Environment, er
 
 	e := &Environment{
 		Vars:       make(map[string]string),
-		Expiration: time.Now().Add(duration).Unix(),
+		Expiration: time.Now().Add(duration),
 	}
 
 	// copy the vault vars to the environment

--- a/lib/vaulted.go
+++ b/lib/vaulted.go
@@ -176,7 +176,7 @@ func GetEnvironment(name, password string) (*Environment, error) {
 
 	env, err := openEnvironment(name, password)
 	if err == nil {
-		expired := time.Now().Add(5 * time.Minute).After(time.Unix(env.Expiration, 0))
+		expired := time.Now().Add(5 * time.Minute).After(env.Expiration)
 		if !expired {
 			return env, nil
 		}

--- a/spawn.go
+++ b/spawn.go
@@ -20,7 +20,7 @@ func (s *Spawn) Run(steward Steward) error {
 	}
 
 	if s.DisplayStatus {
-		expiration := time.Unix(env.Expiration, 0)
+		expiration := env.Expiration
 		timeRemaining := expiration.Sub(time.Now())
 		timeRemaining = time.Second * time.Duration(timeRemaining.Seconds())
 		ask.Print(fmt.Sprintf("%s — expires: %s (%s remaining)\n", s.VaultName, expiration.Format("2 Jan 2006 15:04 MST"), timeRemaining))


### PR DESCRIPTION
This will invalidate existing environment sessions, but is transparent to users (it will simply re-prompt for MFA the next time the environment is opened).