### PR TITLE
Cache the session token before assuming a role

### DIFF
--- a/doc/vaulted-shell.1.md
+++ b/doc/vaulted-shell.1.md
@@ -28,8 +28,10 @@ Vaulted uses the permanent credentials stored in the vault to generate a set of 
 The temporary credentials generated are valid for a specific duration, set in the `vaulted edit` menu. This duration
 may be set between 15m and 36h.
 
-_**Note:** when Vaulted is configured to assume a role, the maximum duration for a vault is `1h`. Configuring higher
-values will cause AWS to return an error when spawning the vault._
+*Note: even if the duration of a vault is set higher than 1 hour, assuming a
+role caps the duration to 1 hour at a time. The session token will still be
+valid for the duration set in the vault, but the assume role will be performed
+each time Vaulted is invoked.*
 
 This impacts the following environment variables:
 

--- a/edit.go
+++ b/edit.go
@@ -536,9 +536,6 @@ func (e *Edit) setDuration(v *vaulted.Vault) {
 	if v.AWSKey != nil && v.AWSKey.ForgoTempCredGeneration == false {
 		maxDuration = 36 * time.Hour
 	}
-	if v.AWSKey != nil && v.AWSKey.Role != "" {
-		maxDuration = time.Hour
-	}
 	readMessage := fmt.Sprintf("Duration (15m–%s): ", formatDuration(maxDuration))
 	dur, err = e.readValue(readMessage)
 	if err == nil {

--- a/lib/vault.go
+++ b/lib/vault.go
@@ -61,13 +61,6 @@ func (v *Vault) CreateEnvironment(extraVars map[string]string) (*Environment, er
 		if err != nil {
 			return nil, err
 		}
-
-		if v.AWSKey.Role != "" {
-			e.AWSCreds, err = e.AWSCreds.AssumeRole(v.AWSKey.Role, duration)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	return e, nil

--- a/lib/vaulted.go
+++ b/lib/vaulted.go
@@ -174,6 +174,22 @@ func GetEnvironment(name, password string) (*Environment, error) {
 		return nil, err
 	}
 
+	env, err := getEnvironment(v, name, password)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.AWSKey != nil && v.AWSKey.Role != "" {
+		env, err = env.Assume(v.AWSKey.Role)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return env, nil
+}
+
+func getEnvironment(v *Vault, name, password string) (*Environment, error) {
 	env, err := openEnvironment(name, password)
 	if err == nil {
 		expired := time.Now().Add(5 * time.Minute).After(env.Expiration)


### PR DESCRIPTION
Even though this ends up masking the actual session duration (because `vaulted shell` will report a 1h duration even if the vault is set to a higher duration), I think the trade-offs are worth it.