### PR TITLE
Change cache expiration tolerance to 15 minutes

### DIFF
--- a/lib/vaulted.go
+++ b/lib/vaulted.go
@@ -192,7 +192,7 @@ func GetEnvironment(name, password string) (*Environment, error) {
 func getEnvironment(v *Vault, name, password string) (*Environment, error) {
 	env, err := openEnvironment(name, password)
 	if err == nil {
-		expired := time.Now().Add(5 * time.Minute).After(env.Expiration)
+		expired := time.Now().Add(15 * time.Minute).After(env.Expiration)
 		if !expired {
 			return env, nil
 		}


### PR DESCRIPTION
It used to be that if the cache would expire within 5 minutes, it was ignored. This proved to be a problem when performing additional STS calls (e.g. assume role) if the expiration was within 15 minutes, so that is going to be our new lower-bound.