### PR TITLE
Add Name to Environment

### DIFF
--- a/default_environment.go
+++ b/default_environment.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/miquella/vaulted/lib"
+)
+
+func DefaultEnvironment() *vaulted.Environment {
+	return &vaulted.Environment{
+		Name:       os.Getenv("VAULTED_ENV"),
+		Expiration: time.Now().Add(time.Hour),
+	}
+}

--- a/env.go
+++ b/env.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/miquella/vaulted/lib"
 )
@@ -97,9 +96,7 @@ func (e *Env) getEnvironment(steward Steward) (*vaulted.Environment, error) {
 	var err error
 
 	// default environment
-	env := &vaulted.Environment{
-		Expiration: time.Now().Add(time.Hour),
-	}
+	env := DefaultEnvironment()
 
 	if e.VaultName != "" {
 		// get specific environment

--- a/env_test.go
+++ b/env_test.go
@@ -15,6 +15,7 @@ var (
 set -x ONE "111111";
 set -x THREE "333";
 set -x TWO "222";
+set -x VAULTED_ENV "one";
 set -x VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 `
 	envFishOutputWithPermCreds = `# To load these variables into your shell, execute:
@@ -26,6 +27,7 @@ set -x AWS_SECRET_ACCESS_KEY "aws-secret-key";
 set -x ONE "111111";
 set -x THREE "333";
 set -x TWO "222";
+set -x VAULTED_ENV "one";
 set -x VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 `
 
@@ -34,6 +36,7 @@ set -x VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 export ONE="111111"
 export THREE="333"
 export TWO="222"
+export VAULTED_ENV="one"
 export VAULTED_ENV_EXPIRATION="2006-01-02T22:04:05Z"
 `
 	envShOutputWithPermCreds = `# To load these variables into your shell, execute:
@@ -45,6 +48,7 @@ export AWS_SECRET_ACCESS_KEY="aws-secret-key"
 export ONE="111111"
 export THREE="333"
 export TWO="222"
+export VAULTED_ENV="one"
 export VAULTED_ENV_EXPIRATION="2006-01-02T22:04:05Z"
 `
 
@@ -52,6 +56,7 @@ export VAULTED_ENV_EXPIRATION="2006-01-02T22:04:05Z"
   "ONE": "111111",
   "THREE": "333",
   "TWO": "222",
+  "VAULTED_ENV": "one",
   "VAULTED_ENV_EXPIRATION": "2006-01-02T22:04:05Z"
 }
 `
@@ -121,6 +126,7 @@ func TestEnv(t *testing.T) {
 
 	// cached environment
 	steward.Environments["one"] = &vaulted.Environment{
+		Name:       "one",
 		Expiration: time.Unix(1136239445, 0),
 		AWSCreds: &vaulted.AWSCredentials{
 			ID:     "aws-key-id",

--- a/lib/environment_test.go
+++ b/lib/environment_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestEnvironmentVariables(t *testing.T) {
 	e := Environment{
+		Name:       "vault",
 		Expiration: time.Now(),
 		Vars: map[string]string{
 			"TEST":         "TESTING",
@@ -16,8 +17,9 @@ func TestEnvironmentVariables(t *testing.T) {
 		},
 	}
 	var expectedSet map[string]string = map[string]string{
-		"ANOTHER_TEST": "TEST TEST",
-		"TEST":         "TESTING",
+		"ANOTHER_TEST":           "TEST TEST",
+		"TEST":                   "TESTING",
+		"VAULTED_ENV":            e.Name,
 		"VAULTED_ENV_EXPIRATION": e.Expiration.UTC().Format(time.RFC3339),
 	}
 	var expectedUnset []string
@@ -35,6 +37,7 @@ func TestEnvironmentVariables(t *testing.T) {
 
 func TestEnvironmentVariablesWithPermCreds(t *testing.T) {
 	e := Environment{
+		Name:       "vault",
 		Expiration: time.Now(),
 		AWSCreds: &AWSCredentials{
 			ID:     "an-id",
@@ -46,10 +49,11 @@ func TestEnvironmentVariablesWithPermCreds(t *testing.T) {
 		},
 	}
 	var expectedSet map[string]string = map[string]string{
-		"ANOTHER_TEST":          "TEST TEST",
-		"AWS_ACCESS_KEY_ID":     e.AWSCreds.ID,
-		"AWS_SECRET_ACCESS_KEY": e.AWSCreds.Secret,
-		"TEST":                  "TESTING",
+		"ANOTHER_TEST":           "TEST TEST",
+		"AWS_ACCESS_KEY_ID":      e.AWSCreds.ID,
+		"AWS_SECRET_ACCESS_KEY":  e.AWSCreds.Secret,
+		"TEST":                   "TESTING",
+		"VAULTED_ENV":            e.Name,
 		"VAULTED_ENV_EXPIRATION": e.Expiration.UTC().Format(time.RFC3339),
 	}
 	var expectedUnset []string = []string{
@@ -71,6 +75,7 @@ func TestEnvironmentVariablesWithPermCreds(t *testing.T) {
 
 func TestEnvironmentVariablesWithTempCreds(t *testing.T) {
 	e := Environment{
+		Name:       "vault",
 		Expiration: time.Now(),
 		AWSCreds: &AWSCredentials{
 			ID:     "an-id",
@@ -83,12 +88,13 @@ func TestEnvironmentVariablesWithTempCreds(t *testing.T) {
 		},
 	}
 	var expectedSet map[string]string = map[string]string{
-		"ANOTHER_TEST":          "TEST TEST",
-		"AWS_ACCESS_KEY_ID":     e.AWSCreds.ID,
-		"AWS_SECRET_ACCESS_KEY": e.AWSCreds.Secret,
-		"AWS_SECURITY_TOKEN":    e.AWSCreds.Token,
-		"AWS_SESSION_TOKEN":     e.AWSCreds.Token,
-		"TEST":                  "TESTING",
+		"ANOTHER_TEST":           "TEST TEST",
+		"AWS_ACCESS_KEY_ID":      e.AWSCreds.ID,
+		"AWS_SECRET_ACCESS_KEY":  e.AWSCreds.Secret,
+		"AWS_SECURITY_TOKEN":     e.AWSCreds.Token,
+		"AWS_SESSION_TOKEN":      e.AWSCreds.Token,
+		"TEST":                   "TESTING",
+		"VAULTED_ENV":            e.Name,
 		"VAULTED_ENV_EXPIRATION": e.Expiration.UTC().Format(time.RFC3339),
 	}
 	var expectedUnset []string

--- a/lib/vault.go
+++ b/lib/vault.go
@@ -25,7 +25,7 @@ type Vault struct {
 	SSHKeys  map[string]string `json:"ssh_keys,omitempty"`
 }
 
-func (v *Vault) CreateEnvironment(extraVars map[string]string) (*Environment, error) {
+func (v *Vault) CreateEnvironment(name string) (*Environment, error) {
 	var duration time.Duration
 	if v.Duration == 0 {
 		duration = STSDurationDefault
@@ -34,15 +34,13 @@ func (v *Vault) CreateEnvironment(extraVars map[string]string) (*Environment, er
 	}
 
 	e := &Environment{
+		Name:       name,
 		Vars:       make(map[string]string),
 		Expiration: time.Now().Add(duration),
 	}
 
 	// copy the vault vars to the environment
 	for key, value := range v.Vars {
-		e.Vars[key] = value
-	}
-	for key, value := range extraVars {
 		e.Vars[key] = value
 	}
 

--- a/lib/vaulted.go
+++ b/lib/vaulted.go
@@ -201,7 +201,7 @@ func getEnvironment(v *Vault, name, password string) (*Environment, error) {
 	// the environment isn't valid (possibly expired), so remove it
 	removeEnvironment(name)
 
-	env, err = v.CreateEnvironment(map[string]string{"VAULTED_ENV": name})
+	env, err = v.CreateEnvironment(name)
 	if err != nil {
 		return nil, err
 	}

--- a/spawn.go
+++ b/spawn.go
@@ -25,7 +25,7 @@ func (s *Spawn) Run(steward Steward) error {
 	timeRemaining := env.Expiration.Sub(time.Now())
 	timeRemaining = time.Second * time.Duration(timeRemaining.Seconds())
 	if s.DisplayStatus {
-		ask.Print(fmt.Sprintf("%s — expires: %s (%s remaining)\n", s.VaultName, env.Expiration.Format("2 Jan 2006 15:04 MST"), timeRemaining))
+		ask.Print(fmt.Sprintf("%s — expires: %s (%s remaining)\n", env.Name, env.Expiration.Format("2 Jan 2006 15:04 MST"), timeRemaining))
 	}
 
 	code, err := env.Spawn(s.Command)
@@ -42,9 +42,7 @@ func (s *Spawn) getEnvironment(steward Steward) (*vaulted.Environment, error) {
 	var err error
 
 	// default environment
-	env := &vaulted.Environment{
-		Expiration: time.Now().Add(time.Hour),
-	}
+	env := DefaultEnvironment()
 
 	if s.VaultName != "" {
 		// get specific environment

--- a/spawn.go
+++ b/spawn.go
@@ -28,7 +28,7 @@ func (s *Spawn) Run(steward Steward) error {
 		ask.Print(fmt.Sprintf("%s — expires: %s (%s remaining)\n", s.VaultName, env.Expiration.Format("2 Jan 2006 15:04 MST"), timeRemaining))
 	}
 
-	code, err := env.Spawn(s.Command, nil)
+	code, err := env.Spawn(s.Command)
 	if err != nil {
 		return ErrorWithExitCode{err, 2}
 	} else if *code != 0 {

--- a/steward_test.go
+++ b/steward_test.go
@@ -150,6 +150,7 @@ func (ts TestSteward) GetEnvironment(name string, password *string) (string, *va
 	if _, exists := ts.Environments[name]; exists {
 		env := ts.Environments[name]
 
+		e.Name = env.Name
 		e.Expiration = env.Expiration
 
 		creds := *env.AWSCreds
@@ -164,6 +165,8 @@ func (ts TestSteward) GetEnvironment(name string, password *string) (string, *va
 		}
 	} else {
 		vault := ts.Vaults[name]
+
+		e.Name = name
 
 		for key, value := range vault.Vars {
 			e.Vars[key] = value


### PR DESCRIPTION
`Name` is now used to source the `VAULTED_ENV` variable (rather than storing the materialized var in the session cache).