### PR TITLE
Fixes and tweaks to `env` output

### DIFF
--- a/args.go
+++ b/args.go
@@ -278,6 +278,14 @@ func parseEnvArgs(args []string) (Command, error) {
 	e.DetectedShell = shell
 	e.Command = strings.Join(os.Args, " ")
 
+	e.Interactive = true
+	fi, err := os.Stdout.Stat()
+	if err == nil {
+		if fi.Mode()&os.ModeCharDevice == 0 {
+			e.Interactive = false
+		}
+	}
+
 	e.Format, _ = flag.GetString("format")
 	return e, nil
 }

--- a/env.go
+++ b/env.go
@@ -41,7 +41,7 @@ var (
 {{ range $var, $value := .Set }}set -gx {{ $var }} "{{ replace $value "\"" "\\\"" }}";
 {{ end }}`,
 		"sh": `# To load these variables into your shell, execute:
-#   eval $({{ .Command }})
+#   eval "$({{ .Command }})"
 {{ range $var := .Unset}}unset {{ $var }}
 {{ end -}}
 {{ range $var, $value := .Set }}export {{ $var }}="{{ replace $value "\"" "\\\"" }}"

--- a/env.go
+++ b/env.go
@@ -38,7 +38,7 @@ var (
 #   eval ({{ .Command }})
 {{ range $var := .Unset}}set -e {{ $var }};
 {{ end -}}
-{{ range $var, $value := .Set }}set -x {{ $var }} "{{ replace $value "\"" "\\\"" }}";
+{{ range $var, $value := .Set }}set -gx {{ $var }} "{{ replace $value "\"" "\\\"" }}";
 {{ end }}`,
 		"sh": `# To load these variables into your shell, execute:
 #   eval $({{ .Command }})

--- a/env.go
+++ b/env.go
@@ -35,7 +35,7 @@ type templateVals struct {
 var (
 	sessionFormatters = map[string]string{
 		"fish": `# To load these variables into your shell, execute:
-#   eval ({{ .Command }})
+#   {{ .Command }} | source
 {{ range $var := .Unset}}set -e {{ $var }};
 {{ end -}}
 {{ range $var, $value := .Set }}set -gx {{ $var }} "{{ replace $value "\"" "\\\"" }}";

--- a/env_test.go
+++ b/env_test.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	envFishOutput = `# To load these variables into your shell, execute:
-#   eval (vaulted env one)
+#   vaulted env one | source
 set -gx ONE "111111";
 set -gx THREE "333";
 set -gx TWO "222";
@@ -19,7 +19,7 @@ set -gx VAULTED_ENV "one";
 set -gx VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 `
 	envFishOutputWithPermCreds = `# To load these variables into your shell, execute:
-#   eval (vaulted env one)
+#   vaulted env one | source
 set -e AWS_SECURITY_TOKEN;
 set -e AWS_SESSION_TOKEN;
 set -gx AWS_ACCESS_KEY_ID "aws-key-id";

--- a/env_test.go
+++ b/env_test.go
@@ -12,23 +12,23 @@ import (
 var (
 	envFishOutput = `# To load these variables into your shell, execute:
 #   eval (vaulted env one)
-set -x ONE "111111";
-set -x THREE "333";
-set -x TWO "222";
-set -x VAULTED_ENV "one";
-set -x VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
+set -gx ONE "111111";
+set -gx THREE "333";
+set -gx TWO "222";
+set -gx VAULTED_ENV "one";
+set -gx VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 `
 	envFishOutputWithPermCreds = `# To load these variables into your shell, execute:
 #   eval (vaulted env one)
 set -e AWS_SECURITY_TOKEN;
 set -e AWS_SESSION_TOKEN;
-set -x AWS_ACCESS_KEY_ID "aws-key-id";
-set -x AWS_SECRET_ACCESS_KEY "aws-secret-key";
-set -x ONE "111111";
-set -x THREE "333";
-set -x TWO "222";
-set -x VAULTED_ENV "one";
-set -x VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
+set -gx AWS_ACCESS_KEY_ID "aws-key-id";
+set -gx AWS_SECRET_ACCESS_KEY "aws-secret-key";
+set -gx ONE "111111";
+set -gx THREE "333";
+set -gx TWO "222";
+set -gx VAULTED_ENV "one";
+set -gx VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 `
 
 	envShOutput = `# To load these variables into your shell, execute:

--- a/env_test.go
+++ b/env_test.go
@@ -32,7 +32,7 @@ set -gx VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 `
 
 	envShOutput = `# To load these variables into your shell, execute:
-#   eval $(vaulted env one)
+#   eval "$(vaulted env one)"
 export ONE="111111"
 export THREE="333"
 export TWO="222"
@@ -40,7 +40,7 @@ export VAULTED_ENV="one"
 export VAULTED_ENV_EXPIRATION="2006-01-02T22:04:05Z"
 `
 	envShOutputWithPermCreds = `# To load these variables into your shell, execute:
-#   eval $(vaulted env one)
+#   eval "$(vaulted env one)"
 unset AWS_SECURITY_TOKEN
 unset AWS_SESSION_TOKEN
 export AWS_ACCESS_KEY_ID="aws-key-id"

--- a/env_test.go
+++ b/env_test.go
@@ -30,6 +30,22 @@ set -gx TWO "222";
 set -gx VAULTED_ENV "one";
 set -gx VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
 `
+	envFishOutputNonInteractive = `set -gx ONE "111111";
+set -gx THREE "333";
+set -gx TWO "222";
+set -gx VAULTED_ENV "one";
+set -gx VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
+`
+	envFishOutputWithPermCredsNonInteractive = `set -e AWS_SECURITY_TOKEN;
+set -e AWS_SESSION_TOKEN;
+set -gx AWS_ACCESS_KEY_ID "aws-key-id";
+set -gx AWS_SECRET_ACCESS_KEY "aws-secret-key";
+set -gx ONE "111111";
+set -gx THREE "333";
+set -gx TWO "222";
+set -gx VAULTED_ENV "one";
+set -gx VAULTED_ENV_EXPIRATION "2006-01-02T22:04:05Z";
+`
 
 	envShOutput = `# To load these variables into your shell, execute:
 #   eval "$(vaulted env one)"
@@ -42,6 +58,23 @@ export VAULTED_ENV_EXPIRATION="2006-01-02T22:04:05Z"
 	envShOutputWithPermCreds = `# To load these variables into your shell, execute:
 #   eval "$(vaulted env one)"
 unset AWS_SECURITY_TOKEN
+unset AWS_SESSION_TOKEN
+export AWS_ACCESS_KEY_ID="aws-key-id"
+export AWS_SECRET_ACCESS_KEY="aws-secret-key"
+export ONE="111111"
+export THREE="333"
+export TWO="222"
+export VAULTED_ENV="one"
+export VAULTED_ENV_EXPIRATION="2006-01-02T22:04:05Z"
+`
+
+	envShOutputNonInteractive = `export ONE="111111"
+export THREE="333"
+export TWO="222"
+export VAULTED_ENV="one"
+export VAULTED_ENV_EXPIRATION="2006-01-02T22:04:05Z"
+`
+	envShOutputWithPermCredsNonInteractive = `unset AWS_SECURITY_TOKEN
 unset AWS_SESSION_TOKEN
 export AWS_ACCESS_KEY_ID="aws-key-id"
 export AWS_SECRET_ACCESS_KEY="aws-secret-key"
@@ -79,6 +112,7 @@ func TestEnv(t *testing.T) {
 			DetectedShell: "fish",
 			Format:        "shell",
 			Command:       "vaulted env one",
+			Interactive:   true,
 		}
 		err := e.Run(steward)
 		if err != nil {
@@ -95,6 +129,7 @@ func TestEnv(t *testing.T) {
 			DetectedShell: "sh",
 			Format:        "shell",
 			Command:       "vaulted env one",
+			Interactive:   true,
 		}
 		err := e.Run(steward)
 		if err != nil {
@@ -103,6 +138,40 @@ func TestEnv(t *testing.T) {
 	})
 	if string(output) != envShOutput {
 		t.Error(failureMessage(envShOutput, output))
+	}
+
+	output = CaptureStdout(func() {
+		e := Env{
+			VaultName:     "one",
+			DetectedShell: "fish",
+			Format:        "shell",
+			Command:       "vaulted env one",
+			Interactive:   false,
+		}
+		err := e.Run(steward)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+	if string(output) != envFishOutputNonInteractive {
+		t.Error(failureMessage(envFishOutputNonInteractive, output))
+	}
+
+	output = CaptureStdout(func() {
+		e := Env{
+			VaultName:     "one",
+			DetectedShell: "sh",
+			Format:        "shell",
+			Command:       "vaulted env one",
+			Interactive:   false,
+		}
+		err := e.Run(steward)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+	if string(output) != envShOutputNonInteractive {
+		t.Error(failureMessage(envShOutputNonInteractive, output))
 	}
 
 	output = CaptureStdout(func() {
@@ -145,6 +214,7 @@ func TestEnv(t *testing.T) {
 			DetectedShell: "fish",
 			Format:        "fish",
 			Command:       "vaulted env one",
+			Interactive:   true,
 		}
 		err := e.Run(steward)
 		if err != nil {
@@ -161,6 +231,7 @@ func TestEnv(t *testing.T) {
 			DetectedShell: "sh",
 			Format:        "shell",
 			Command:       "vaulted env one",
+			Interactive:   true,
 		}
 		err := e.Run(steward)
 		if err != nil {
@@ -168,8 +239,39 @@ func TestEnv(t *testing.T) {
 		}
 	})
 
-	if string(output) != envShOutputWithPermCreds {
-		t.Error(failureMessage(envShOutputWithPermCreds, output))
+	output = CaptureStdout(func() {
+		e := Env{
+			VaultName:     "one",
+			DetectedShell: "fish",
+			Format:        "fish",
+			Command:       "vaulted env one",
+			Interactive:   false,
+		}
+		err := e.Run(steward)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+	if string(output) != envFishOutputWithPermCredsNonInteractive {
+		t.Error(failureMessage(envFishOutputWithPermCredsNonInteractive, output))
+	}
+
+	output = CaptureStdout(func() {
+		e := Env{
+			VaultName:     "one",
+			DetectedShell: "sh",
+			Format:        "shell",
+			Command:       "vaulted env one",
+			Interactive:   false,
+		}
+		err := e.Run(steward)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	if string(output) != envShOutputWithPermCredsNonInteractive {
+		t.Error(failureMessage(envShOutputWithPermCredsNonInteractive, output))
 	}
 
 	output = CaptureStdout(func() {


### PR DESCRIPTION
It was discovered that all of the `env` output formatters needed to be tweaked in some way or another. _Mostly_ oriented around the suggested commands for loading things into an existing environment.