### PR TITLE
Set session expiration after calling STS

### DIFF
--- a/lib/vault.go
+++ b/lib/vault.go
@@ -37,9 +37,8 @@ func (v *Vault) CreateSession(name string) (*Session, error) {
 	}
 
 	s := &Session{
-		Name:       name,
-		Vars:       make(map[string]string),
-		Expiration: time.Now().Add(duration).Truncate(time.Second),
+		Name: name,
+		Vars: make(map[string]string),
 	}
 
 	// copy the vault vars to the session
@@ -63,6 +62,9 @@ func (v *Vault) CreateSession(name string) (*Session, error) {
 			return nil, err
 		}
 	}
+
+	// now that the session is generated, set the expiration
+	s.Expiration = time.Now().Add(duration).Truncate(time.Second)
 
 	return s, nil
 }


### PR DESCRIPTION
Because the session expiration was set before prompting the user for
their MFA token, the duration was shorted by how long it took the user
to input their token. Instead, we set the expiration after getting the
user's token and calling STS.