### PR TITLE
Create a linux installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ The easiest way to install `vaulted` on macOS is through
 brew install vaulted
 ```
 
+### Linux
+
+If you already have [Linux Brew](http://linuxbrew.sh/) installed
+
+```sh
+brew install vaulted
+```
+
+If you do not use Linux Brew, you will need to [build vaulted manually](#manual).
+
 ### Manual
 
 Installation on other platforms should be simple enough through `go get` as


### PR DESCRIPTION
I tested installation under linux brew and it works. This adds linux
brew instructions to the README.md

Given how simple these instructions are, maybe it's not worth having a section in the README.md :man_shrugging: 

I generally skim for a "linux" section tho when installing and I would personally find this helpful.