### PR TITLE
Fix sealing a vault to return filesystem errors

### DIFF
--- a/lib/vaulted.go
+++ b/lib/vaulted.go
@@ -102,9 +102,7 @@ func SealVault(name, password string, vault *Vault) error {
 		return fmt.Errorf("Invalid encryption method: %s", vf.Method)
 	}
 
-	writeVaultFile(name, vf)
-
-	return nil
+	return writeVaultFile(name, vf)
 }
 
 func OpenVault(name, password string) (*Vault, error) {


### PR DESCRIPTION
File system errors that happen when sealing a vault are not propagated out to the caller, potentially not informing the user when failing to write a vault.