### PR TITLE
Display message when creating a new vault

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -53,6 +53,7 @@ func (e *Edit) Run(steward Steward) error {
 			return ErrExists
 		}
 
+		fmt.Printf("Creating new vault '%s'...\n", e.VaultName)
 		vault = &vaulted.Vault{}
 
 		creds, err := e.importExistingCreds()


### PR DESCRIPTION
Sometimes detecting AWS credentials in the environment can take several seconds. To smooth this over for users creating a new vault, we should display a message indicating that Vaulted is working.