### PR TITLE
don't prompt for mfa when sts is forgone

### DIFF
--- a/lib/vault.go
+++ b/lib/vault.go
@@ -87,7 +87,7 @@ func (k *AWSKey) Valid() bool {
 }
 
 func (k *AWSKey) RequiresMFA() bool {
-	return k.Valid() && k.MFA != ""
+	return k.Valid() && !k.ForgoTempCredGeneration && k.MFA != ""
 }
 
 func (k *AWSKey) GetAWSCredentials(duration time.Duration) (*AWSCredentials, error) {


### PR DESCRIPTION
corrects a regression introduced when mfa was moved into the steward:
ab89974190163d2241897c4a11f3157077761f2a