### PR TITLE
Empower MFA prompt w/ ctrl modifiers

### DIFF
--- a/steward.go
+++ b/steward.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/chzyer/readline"
 	"github.com/miquella/ask"
 	"github.com/miquella/vaulted/lib"
 	"github.com/miquella/vaulted/lib/legacy"
@@ -156,6 +157,14 @@ func (t *TTYSteward) GetPassword(operation vaulted.Operation, name string) (stri
 }
 
 func (t *TTYSteward) GetMFAToken(name string) (string, error) {
-	token, err := ask.Ask("   MFA token: ")
+	reader, err := readline.New("   MFA token: ")
+	if err != nil {
+		return "", err
+	}
+	token, err := reader.Readline()
+	if err != nil {
+		return "", err
+	}
+
 	return strings.TrimSpace(token), err
 }


### PR DESCRIPTION
This makes it possible to Ctrl-W and clear the line, and other line modifiers in the MFA prompt.