### PR TITLE
Abstract out aws key

### DIFF
--- a/lib/aws_key.go
+++ b/lib/aws_key.go
@@ -1,0 +1,38 @@
+package vaulted
+
+import (
+	"time"
+)
+
+type AWSKey struct {
+	AWSCredentials
+	MFA                     string `json:"mfa,omitempty"`
+	Role                    string `json:"role,omitempty"`
+	ForgoTempCredGeneration bool   `json:"forgoTempCredGeneration"`
+}
+
+func (k *AWSKey) Valid() bool {
+	return k != nil && k.AWSCredentials.Valid()
+}
+
+func (k *AWSKey) RequiresMFA() bool {
+	return k.Valid() && !k.ForgoTempCredGeneration && k.MFA != ""
+}
+
+func (k *AWSKey) GetAWSCredentials(duration time.Duration) (*AWSCredentials, error) {
+	if k.ForgoTempCredGeneration {
+		creds := k.AWSCredentials
+		return &creds, nil
+	}
+
+	return k.AWSCredentials.GetSessionToken(duration)
+}
+
+func (k *AWSKey) GetAWSCredentialsWithMFA(mfaToken string, duration time.Duration) (*AWSCredentials, error) {
+	if k.ForgoTempCredGeneration {
+		creds := k.AWSCredentials
+		return &creds, nil
+	}
+
+	return k.AWSCredentials.GetSessionTokenWithMFA(k.MFA, mfaToken, duration)
+}

--- a/lib/vault.go
+++ b/lib/vault.go
@@ -74,36 +74,3 @@ func (v *Vault) createSession(name string, credsFunc func(duration time.Duration
 
 	return s, nil
 }
-
-type AWSKey struct {
-	AWSCredentials
-	MFA                     string `json:"mfa,omitempty"`
-	Role                    string `json:"role,omitempty"`
-	ForgoTempCredGeneration bool   `json:"forgoTempCredGeneration"`
-}
-
-func (k *AWSKey) Valid() bool {
-	return k != nil && k.AWSCredentials.Valid()
-}
-
-func (k *AWSKey) RequiresMFA() bool {
-	return k.Valid() && !k.ForgoTempCredGeneration && k.MFA != ""
-}
-
-func (k *AWSKey) GetAWSCredentials(duration time.Duration) (*AWSCredentials, error) {
-	if k.ForgoTempCredGeneration {
-		creds := k.AWSCredentials
-		return &creds, nil
-	}
-
-	return k.AWSCredentials.GetSessionToken(duration)
-}
-
-func (k *AWSKey) GetAWSCredentialsWithMFA(mfaToken string, duration time.Duration) (*AWSCredentials, error) {
-	if k.ForgoTempCredGeneration {
-		creds := k.AWSCredentials
-		return &creds, nil
-	}
-
-	return k.AWSCredentials.GetSessionTokenWithMFA(k.MFA, mfaToken, duration)
-}


### PR DESCRIPTION
Vault was conflated w/ the AWS Key struct.  This cleans that up.