### PR TITLE
Add minimum go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ long as you have a proper Go environment setup:
 go get -u github.com/miquella/vaulted
 ```
 
-Don't forget to add `$GOPATH/bin` to your `$PATH`!
+Don't forget to add `$GOPATH/bin` to your `$PATH`! You must be running go version
+1.9 or greater.
 
 Getting Started
 ---------------


### PR DESCRIPTION
There is no indication to users that you must have at least 1.9 of go to get the installation to work manually. Add a minimum go version.