### PR TITLE
Add role partition and fix role path

### DIFF
--- a/lib/session.go
+++ b/lib/session.go
@@ -206,11 +206,11 @@ func (e *Session) Variables() *Variables {
 
 		roleArn, err := arn.Parse(e.Role)
 		if err == nil {
-			resource := strings.TrimPrefix(roleArn.Resource, "role")
+			resource := strings.TrimPrefix(roleArn.Resource, "role/")
 			vars.Set["VAULTED_ENV_ROLE_PARTITION"] = roleArn.Partition
 			vars.Set["VAULTED_ENV_ROLE_ACCOUNT_ID"] = roleArn.AccountID
 			vars.Set["VAULTED_ENV_ROLE_NAME"] = path.Base(resource)
-			vars.Set["VAULTED_ENV_ROLE_PATH"] = path.Dir(resource)
+			vars.Set["VAULTED_ENV_ROLE_PATH"] = fmt.Sprintf("/%s/", path.Dir(resource))
 		}
 	}
 

--- a/lib/session.go
+++ b/lib/session.go
@@ -207,6 +207,7 @@ func (e *Session) Variables() *Variables {
 		roleArn, err := arn.Parse(e.Role)
 		if err == nil {
 			resource := strings.TrimPrefix(roleArn.Resource, "role")
+			vars.Set["VAULTED_ENV_ROLE_PARTITION"] = roleArn.Partition
 			vars.Set["VAULTED_ENV_ROLE_ACCOUNT_ID"] = roleArn.AccountID
 			vars.Set["VAULTED_ENV_ROLE_NAME"] = path.Base(resource)
 			vars.Set["VAULTED_ENV_ROLE_PATH"] = path.Dir(resource)


### PR DESCRIPTION
The role's partition was not exposed and the role path was exposed differently than AWS represents it, so this was fixed.