### PR TITLE
Fix automatic credential detection

### DIFF
--- a/menu/import_credentials.go
+++ b/menu/import_credentials.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/fatih/color"
 	"github.com/miquella/vaulted/lib"
 )
@@ -15,7 +15,14 @@ type ImportCredentialsMenu struct {
 }
 
 func (m *ImportCredentialsMenu) Handler() error {
-	creds, err := defaults.Get().Config.Credentials.Get()
+	credsChain := credentials.NewCredentials(&credentials.ChainProvider{
+		Providers: []credentials.Provider{
+			&credentials.EnvProvider{},
+			&credentials.SharedCredentialsProvider{},
+		},
+	})
+
+	creds, err := credsChain.Get()
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Remote credentials provided by the metadata service(s) are always session credentials and are not eligible to be imported into Vaulted, so those credential providers have been excluded so as to speed things up.