### PR TITLE
Add simple method to invalidate old sessions

### DIFF
--- a/default_environment.go
+++ b/default_environment.go
@@ -9,6 +9,8 @@ import (
 
 func DefaultSession() *vaulted.Session {
 	return &vaulted.Session{
+		SessionVersion: vaulted.SessionVersion,
+
 		Name:       os.Getenv("VAULTED_ENV"),
 		Expiration: time.Now().Add(time.Hour).Truncate(time.Second),
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -202,8 +202,11 @@ func TestEnv(t *testing.T) {
 
 	// cached session
 	store.Sessions["one"] = &vaulted.Session{
+		SessionVersion: vaulted.SessionVersion,
+
 		Name:       "one",
 		Expiration: time.Unix(1136239445, 0),
+
 		AWSCreds: &vaulted.AWSCredentials{
 			ID:     "aws-key-id",
 			Secret: "aws-secret-key",

--- a/lib/session.go
+++ b/lib/session.go
@@ -15,13 +15,21 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
+var (
+	SessionVersion = ""
+)
+
 type Session struct {
-	Name       string            `json:"name"`
-	Role       string            `json:"role,omitempty"`
-	Expiration time.Time         `json:"expiration"`
-	AWSCreds   *AWSCredentials   `json:"aws_creds,omitempty"`
-	Vars       map[string]string `json:"vars,omitempty"`
-	SSHKeys    map[string]string `json:"ssh_keys,omitempty"`
+	SessionVersion string `json:"version"`
+
+	Name       string    `json:"name"`
+	Expiration time.Time `json:"expiration"`
+
+	Role string `json:"role,omitempty"`
+
+	AWSCreds *AWSCredentials   `json:"aws_creds,omitempty"`
+	Vars     map[string]string `json:"vars,omitempty"`
+	SSHKeys  map[string]string `json:"ssh_keys,omitempty"`
 }
 
 func (e *Session) Assume(roleArn string) (*Session, error) {
@@ -65,12 +73,16 @@ func (e *Session) Assume(roleArn string) (*Session, error) {
 	}
 
 	session := &Session{
+		SessionVersion: SessionVersion,
+
 		Name:       e.Name,
-		Role:       selectedRoleArn,
 		Expiration: *creds.Expiration,
-		AWSCreds:   creds,
-		Vars:       make(map[string]string),
-		SSHKeys:    make(map[string]string),
+
+		Role: selectedRoleArn,
+
+		AWSCreds: creds,
+		Vars:     make(map[string]string),
+		SSHKeys:  make(map[string]string),
 	}
 	for key, value := range e.Vars {
 		session.Vars[key] = value

--- a/lib/session_test.go
+++ b/lib/session_test.go
@@ -9,8 +9,11 @@ import (
 
 func TestSessionVariables(t *testing.T) {
 	e := Session{
+		SessionVersion: SessionVersion,
+
 		Name:       "vault",
 		Expiration: time.Now(),
+
 		Vars: map[string]string{
 			"TEST":         "TESTING",
 			"ANOTHER_TEST": "TEST TEST",
@@ -37,8 +40,11 @@ func TestSessionVariables(t *testing.T) {
 
 func TestSessionVariablesWithPermCreds(t *testing.T) {
 	e := Session{
+		SessionVersion: SessionVersion,
+
 		Name:       "vault",
 		Expiration: time.Now(),
+
 		AWSCreds: &AWSCredentials{
 			ID:     "an-id",
 			Secret: "the-super-sekrit",
@@ -75,8 +81,11 @@ func TestSessionVariablesWithPermCreds(t *testing.T) {
 
 func TestSessionVariablesWithTempCreds(t *testing.T) {
 	e := Session{
+		SessionVersion: SessionVersion,
+
 		Name:       "vault",
 		Expiration: time.Now(),
+
 		AWSCreds: &AWSCredentials{
 			ID:     "an-id",
 			Secret: "the-super-sekrit",

--- a/lib/store.go
+++ b/lib/store.go
@@ -393,5 +393,9 @@ func (s *store) openSession(name, password string) (*Session, error) {
 		return nil, fmt.Errorf("Invalid encryption method: %s", sf.Method)
 	}
 
+	if session.SessionVersion != SessionVersion {
+		return nil, fmt.Errorf("Invalid session version: %s", session.SessionVersion)
+	}
+
 	return &session, nil
 }

--- a/lib/vault.go
+++ b/lib/vault.go
@@ -44,7 +44,10 @@ func (v *Vault) newSession(name string, credsFunc func(duration time.Duration) (
 	}
 
 	s := &Session{
+		SessionVersion: SessionVersion,
+
 		Name: name,
+
 		Vars: make(map[string]string),
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -146,9 +146,12 @@ func (ts TestStore) GetSession(name string) (*vaulted.Session, string, error) {
 	}
 
 	s := &vaulted.Session{
+		SessionVersion: vaulted.SessionVersion,
+
 		Expiration: time.Unix(1136239445, 0),
-		Vars:       make(map[string]string),
-		SSHKeys:    make(map[string]string),
+
+		Vars:    make(map[string]string),
+		SSHKeys: make(map[string]string),
 	}
 	if _, exists := ts.Sessions[name]; exists {
 		cachedSession := ts.Sessions[name]
@@ -189,9 +192,12 @@ func (ts TestStore) CreateSession(name string) (*vaulted.Session, string, error)
 	}
 
 	s := &vaulted.Session{
+		SessionVersion: vaulted.SessionVersion,
+
 		Expiration: time.Unix(1136239446, 0),
-		Vars:       make(map[string]string),
-		SSHKeys:    make(map[string]string),
+
+		Vars:    make(map[string]string),
+		SSHKeys: make(map[string]string),
 	}
 	vault := ts.Vaults[name]
 


### PR DESCRIPTION
If the `SessionVersion` package variable is changed (e.g. to "2"),
previously cached sessions will be considered invalid.

This can be used to ensure old session caches are ignored when the
session cache format changes.