### PR TITLE
fix back option in AWS cli menu

### DIFF
--- a/menu/main.go
+++ b/menu/main.go
@@ -34,7 +34,7 @@ func (m *MainMenu) Handler() error {
 		}
 		switch input {
 		case "a", "aws":
-			return awsMenu.Handler()
+			err = awsMenu.Handler()
 		case "s", "ssh":
 			err = sshKeysMenu.Handler()
 		case "v", "vars", "variables":


### PR DESCRIPTION
the recent edit refactor broke the back option in the AWS menu
such that it saves and quits instead of returning to the previous
menu