### PR TITLE
Fix error handling for main menu

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -51,7 +51,7 @@ func (e *Edit) Run(store vaulted.Store) error {
 		}
 	}
 
-	e.edit(e.VaultName, vault)
+	err = e.edit(e.VaultName, vault)
 	if err != nil {
 		return err
 	}

--- a/menu/main.go
+++ b/menu/main.go
@@ -28,7 +28,8 @@ func (m *MainMenu) Handler() error {
 		sshKeysMenu.Printer()
 		durationMenu.Printer()
 
-		input, err := interaction.ReadMenu("Edit vault: [a,s,v,d,S]: ")
+		var input string
+		input, err = interaction.ReadMenu("Edit vault: [a,s,v,d,S]: ")
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
Errors returned from the main menu were not being captured and the main menu was shadowing errors from prompts, so the error was always returned as `nil`.