### PR TITLE
Change Environment verbiage to Session

### DIFF
--- a/menu/duration.go
+++ b/menu/duration.go
@@ -49,7 +49,7 @@ func (m *DurationMenu) formatDuration(duration time.Duration) string {
 }
 
 func (m *DurationMenu) Printer() {
-	cyan.Println("\nEnvironment:")
+	cyan.Println("\nSession:")
 	green.Print("  Duration: ")
 	var duration time.Duration
 	if m.Vault.Duration == 0 {

--- a/menu/main.go
+++ b/menu/main.go
@@ -70,7 +70,7 @@ func (m *MainMenu) Help() {
 	fmt.Println("a - AWS Key")
 	fmt.Println("s - SSH Keys")
 	fmt.Println("v - Variables")
-	fmt.Println("d - Environment Duration")
+	fmt.Println("d - Session Duration")
 	fmt.Println("S - Show/Hide Secrets")
 	fmt.Println("? - Help")
 	fmt.Println("q - Quit")


### PR DESCRIPTION
Using "Environment" to reference more global settings can be very
confusing to users when environment variables are also included in the
display. Session is a bit more clear in Vaulted.