### PR TITLE
Bump the number of PBKDF2 iterations

### DIFF
--- a/lib/vault_file.go
+++ b/lib/vault_file.go
@@ -14,6 +14,11 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
+const (
+	BaseIterations          = 1 << 17
+	AdditionIterationsRange = 1 << 18
+)
+
 type VaultFile struct {
 	Key *VaultKey `json:"key"`
 
@@ -86,10 +91,10 @@ func newVaultKey(previous *VaultKey) *VaultKey {
 		method = "pbkdf2-sha512"
 		details = make(Details)
 
-		iterations := 65536
-		r, err := rand.Int(rand.Reader, big.NewInt(32768))
+		iterations := BaseIterations
+		r, err := rand.Int(rand.Reader, big.NewInt(AdditionIterationsRange))
 		if err == nil {
-			iterations = 65536 + int(r.Int64())
+			iterations += int(r.Int64())
 		}
 
 		details.SetInt("iterations", iterations)


### PR DESCRIPTION
The number of iterations used by PBKDF2 helps to decrease the effectiveness of brute-force attacks against the key for a vault. This bump should help to provide a little more resilience while keeping the amount of time required to derive the necessary key in the low, sub-second range.

This will only take effect for newly created vaults, existing vaults won't be affected, even if edited.