### PR TITLE
Display short and primary aliases for menus

### DIFF
--- a/menu/aws.go
+++ b/menu/aws.go
@@ -17,15 +17,15 @@ func (m *AWSMenu) Help() {
 	menuColor.Set()
 	defer color.Unset()
 
-	fmt.Println("k - Key")
-	fmt.Println("m - MFA")
-	fmt.Println("r - Role")
-	fmt.Println("t - Substitute with temporary credentials")
-	fmt.Println("S - Show/Hide Secrets")
-	fmt.Println("D - Delete")
-	fmt.Println("? - Help")
-	fmt.Println("b - Back")
-	fmt.Println("q - Quit")
+	fmt.Println("k,key    - Key")
+	fmt.Println("m,mfa    - MFA")
+	fmt.Println("r,role   - Role")
+	fmt.Println("t,temp   - Substitute with temporary credentials")
+	fmt.Println("S,show   - Show/Hide Secrets")
+	fmt.Println("D,delete - Delete")
+	fmt.Println("?,help   - Help")
+	fmt.Println("b,back   - Back")
+	fmt.Println("q,quit   - Quit")
 }
 
 func (m *AWSMenu) Handler() error {

--- a/menu/main.go
+++ b/menu/main.go
@@ -67,11 +67,11 @@ func (m *MainMenu) Help() {
 	menuColor.Set()
 	defer color.Unset()
 
-	fmt.Println("a - AWS Key")
-	fmt.Println("s - SSH Keys")
-	fmt.Println("v - Variables")
-	fmt.Println("d - Session Duration")
-	fmt.Println("S - Show/Hide Secrets")
-	fmt.Println("? - Help")
-	fmt.Println("q - Quit")
+	fmt.Println("a,aws      - AWS Key")
+	fmt.Println("s,ssh      - SSH Keys")
+	fmt.Println("v,vars     - Variables")
+	fmt.Println("d,duration - Session Duration")
+	fmt.Println("S,show     - Show/Hide Secrets")
+	fmt.Println("?,help     - Help")
+	fmt.Println("q,quit     - Quit")
 }

--- a/menu/ssh_keys.go
+++ b/menu/ssh_keys.go
@@ -23,11 +23,11 @@ func (m *SSHKeyMenu) Help() {
 	menuColor.Set()
 	defer color.Unset()
 
-	fmt.Println("a - Add")
-	fmt.Println("D - Delete")
-	fmt.Println("? - Help")
-	fmt.Println("b - Back")
-	fmt.Println("q - Quit")
+	fmt.Println("a,add    - Add")
+	fmt.Println("D,delete - Delete")
+	fmt.Println("?,help   - Help")
+	fmt.Println("b,back   - Back")
+	fmt.Println("q,quit   - Quit")
 }
 
 func (m *SSHKeyMenu) Handler() error {

--- a/menu/variables.go
+++ b/menu/variables.go
@@ -83,12 +83,12 @@ func (m *VariableMenu) Help() {
 	color.Set(color.FgYellow)
 	defer color.Unset()
 	fmt.Println("")
-	fmt.Println("a - Add")
-	fmt.Println("S - Show/Hide Secrets")
-	fmt.Println("D - Delete")
-	fmt.Println("? - Help")
-	fmt.Println("b - Back")
-	fmt.Println("q - Quit")
+	fmt.Println("a,add    - Add")
+	fmt.Println("S,show   - Show/Hide Secrets")
+	fmt.Println("D,delete - Delete")
+	fmt.Println("?,help   - Help")
+	fmt.Println("b,back   - Back")
+	fmt.Println("q,quit   - Quit")
 }
 
 func (m *VariableMenu) Printer() {


### PR DESCRIPTION
Some people prefer the long alias versions of the menu commands and there's no reason to hide them in the help command!