### PR TITLE
Re-prompt for MFA when invalid

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 	ErrNoError           = errors.New("")
 	ErrFileNotExist      = ErrorWithExitCode{os.ErrNotExist, EX_USAGE_ERROR}
 	ErrNoPasswordEntered = ErrorWithExitCode{errors.New("Could not get password"), EX_UNAVAILABLE}
+	ErrNoMFATokenEntered = ErrorWithExitCode{errors.New("Could not get MFA token"), EX_UNAVAILABLE}
 )
 
 func main() {


### PR DESCRIPTION
According to the AWS STS documentation, the `TokenCode` parameter must be exactly 6 characters and match: `[\d]*`

See:
[AssumeRole documentation](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_RequestParameters)
[GetSessionToken documentation](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html#API_GetSessionToken_RequestParameters)

Fixes #145