### PR TITLE
Fix XDG_CACHE_HOME varname in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ this directory should be backed up. Session cache files do not need to be retain
 
 **Session** cache files are stored in:
 
-* `$XDG_CACHE/vaulted/` _(typically `~/.cache/vaulted/`)_
+* `$XDG_CACHE_HOME/vaulted/` _(typically `~/.cache/vaulted/`)_
 
 [xdg]: https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 

--- a/doc/man/vaulted.1
+++ b/doc/man/vaulted.1
@@ -82,7 +82,7 @@ this directory should be backed up. Session cache files do not need to be retain
 \fBSession\fP cache files are stored in:
 .RS
 .IP \(bu 2
-\fB\fC$XDG_CACHE/vaulted/\fR \fI(typically \fB\fC~/.cache/vaulted/\fR)\fP
+\fB\fC$XDG_CACHE_HOME/vaulted/\fR \fI(typically \fB\fC~/.cache/vaulted/\fR)\fP
 .RE
 .SH EXIT CODES
 .TS

--- a/doc/vaulted.1.md
+++ b/doc/vaulted.1.md
@@ -76,7 +76,7 @@ this directory should be backed up. Session cache files do not need to be retain
 
 **Session** cache files are stored in:
 
-* `$XDG_CACHE/vaulted/` _(typically `~/.cache/vaulted/`)_
+* `$XDG_CACHE_HOME/vaulted/` _(typically `~/.cache/vaulted/`)_
 
 [xdg]: https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 


### PR DESCRIPTION
the `go get -u github.com/jteeuwen/go-bindata` didn't seem to install an executable (i get a warning running `go generate`), so i just perl'ed the 3 files `¯\_(ツ)_/¯`