### PR TITLE
Add HashiCorp Vault SSH key signing

### DIFF
--- a/lib/vault.go
+++ b/lib/vault.go
@@ -16,11 +16,17 @@ var (
 	ErrNoTokenEntered = errors.New("Could not get MFA code")
 )
 
+type SSHOptions struct {
+	ValidPrincipals []string `json:"valid_principals,omitempty"`
+	VaultSigningUrl string   `json:"vault_signing_url,omitempty"`
+}
+
 type Vault struct {
-	Duration time.Duration     `json:"duration,omitempty"`
-	AWSKey   *AWSKey           `json:"aws_key,omitempty"`
-	Vars     map[string]string `json:"vars,omitempty"`
-	SSHKeys  map[string]string `json:"ssh_keys,omitempty"`
+	Duration   time.Duration     `json:"duration,omitempty"`
+	AWSKey     *AWSKey           `json:"aws_key,omitempty"`
+	Vars       map[string]string `json:"vars,omitempty"`
+	SSHKeys    map[string]string `json:"ssh_keys,omitempty"`
+	SSHOptions *SSHOptions       `json:"ssh_options,omitempty"`
 }
 
 func (v *Vault) NewSession(name string) (*Session, error) {
@@ -48,7 +54,8 @@ func (v *Vault) newSession(name string, credsFunc func(duration time.Duration) (
 	s := &Session{
 		Name: name,
 
-		Vars: make(map[string]string),
+		SSHOptions: &SSHOptions{},
+		Vars:       make(map[string]string),
 	}
 
 	// copy the vault vars to the session
@@ -62,6 +69,11 @@ func (v *Vault) newSession(name string, credsFunc func(duration time.Duration) (
 		for key, value := range v.SSHKeys {
 			s.SSHKeys[key] = value
 		}
+	}
+
+	// copy the vault ssh options to the session
+	if v.SSHOptions != nil {
+		s.SSHOptions = v.SSHOptions
 	}
 
 	if v.AWSKey.Valid() {

--- a/main_test.go
+++ b/main_test.go
@@ -148,8 +148,9 @@ func (ts TestStore) GetSession(vault *vaulted.Vault, name, password string) (*va
 	s := &vaulted.Session{
 		Expiration: time.Unix(1136239445, 0),
 
-		Vars:    make(map[string]string),
-		SSHKeys: make(map[string]string),
+		Vars:       make(map[string]string),
+		SSHKeys:    make(map[string]string),
+		SSHOptions: &vaulted.SSHOptions{},
 	}
 	if _, exists := ts.Sessions[name]; exists {
 		cachedSession := ts.Sessions[name]
@@ -167,6 +168,10 @@ func (ts TestStore) GetSession(vault *vaulted.Vault, name, password string) (*va
 		for key, value := range cachedSession.SSHKeys {
 			s.SSHKeys[key] = value
 		}
+
+		if cachedSession.SSHOptions != nil {
+			s.SSHOptions = cachedSession.SSHOptions
+		}
 	} else {
 		s.Name = name
 
@@ -176,6 +181,10 @@ func (ts TestStore) GetSession(vault *vaulted.Vault, name, password string) (*va
 
 		for key, value := range vault.SSHKeys {
 			s.SSHKeys[key] = value
+		}
+
+		if vault.SSHOptions != nil {
+			s.SSHOptions = vault.SSHOptions
 		}
 	}
 
@@ -190,8 +199,9 @@ func (ts TestStore) CreateSession(vault *vaulted.Vault, name, password string) (
 	s := &vaulted.Session{
 		Expiration: time.Unix(1136239446, 0),
 
-		Vars:    make(map[string]string),
-		SSHKeys: make(map[string]string),
+		Vars:       make(map[string]string),
+		SSHKeys:    make(map[string]string),
+		SSHOptions: &vaulted.SSHOptions{},
 	}
 
 	s.Name = name
@@ -212,8 +222,9 @@ func (ts TestStore) OpenLegacyVault() (environments map[string]legacy.Environmen
 
 func cloneVault(vault *vaulted.Vault) *vaulted.Vault {
 	newVault := &vaulted.Vault{
-		Vars:    make(map[string]string),
-		SSHKeys: make(map[string]string),
+		Vars:       make(map[string]string),
+		SSHKeys:    make(map[string]string),
+		SSHOptions: &vaulted.SSHOptions{},
 	}
 
 	if vault.AWSKey != nil {
@@ -233,6 +244,10 @@ func cloneVault(vault *vaulted.Vault) *vaulted.Vault {
 
 	for key, value := range vault.SSHKeys {
 		newVault.SSHKeys[key] = value
+	}
+
+	if vault.SSHOptions != nil {
+		newVault.SSHOptions = vault.SSHOptions
 	}
 
 	return newVault

--- a/menu/ssh_keys.go
+++ b/menu/ssh_keys.go
@@ -13,6 +13,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/miquella/ask"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/miquella/vaulted/lib"
 )
 
 type SSHKeyMenu struct {
@@ -25,6 +27,7 @@ func (m *SSHKeyMenu) Help() {
 
 	fmt.Println("a,add    - Add")
 	fmt.Println("D,delete - Delete")
+	fmt.Println("v        - Vault Signing URL")
 	fmt.Println("?,help   - Help")
 	fmt.Println("b,back   - Back")
 	fmt.Println("q,quit   - Quit")
@@ -34,7 +37,7 @@ func (m *SSHKeyMenu) Handler() error {
 	for {
 		var err error
 		m.Printer()
-		input, err := interaction.ReadMenu("Edit ssh keys: [a,D,b]: ")
+		input, err := interaction.ReadMenu("Edit ssh keys: [a,D,v,b]: ")
 		if err != nil {
 			return err
 		}
@@ -51,6 +54,15 @@ func (m *SSHKeyMenu) Handler() error {
 					color.Red("Key '%s' not found", key)
 				}
 			}
+		case "v":
+			signingUrl, err := interaction.ReadValue("Vault signing URL: ")
+			if err != nil {
+				return err
+			}
+			if m.Vault.SSHOptions == nil {
+				m.Vault.SSHOptions = &vaulted.SSHOptions{}
+			}
+			m.Vault.SSHOptions.VaultSigningUrl = signingUrl
 		case "b", "back":
 			return nil
 		case "q", "quit", "exit":
@@ -219,5 +231,12 @@ func (m *SSHKeyMenu) Printer() {
 		}
 	} else {
 		fmt.Println("  [Empty]")
+	}
+
+	if m.Vault.SSHOptions != nil {
+		if m.Vault.SSHOptions.VaultSigningUrl != "" {
+			cyan.Printf("\nVault Signing URL: ")
+			fmt.Printf("%s\n", m.Vault.SSHOptions.VaultSigningUrl)
+		}
 	}
 }

--- a/spawn.go
+++ b/spawn.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/miquella/ask"
-	"github.com/miquella/ssh-proxy-agent/lib/proxyagent"
 
 	"github.com/miquella/vaulted/lib"
 )
@@ -29,12 +28,7 @@ func (s *Spawn) Run(store vaulted.Store) error {
 		ask.Print(fmt.Sprintf("%s — expires: %s (%s remaining)\n", session.Name, session.Expiration.Format("2 Jan 2006 15:04 MST"), timeRemaining))
 	}
 
-	sshAgent, err := proxyagent.SetupAgent(proxyagent.AgentConfig{})
-	if err != nil {
-		return ErrorWithExitCode{err, 1}
-	}
-
-	code, err := session.Spawn(s.Command, sshAgent)
+	code, err := session.Spawn(s.Command)
 	if err != nil {
 		return ErrorWithExitCode{err, 2}
 	} else if *code != 0 {


### PR DESCRIPTION
add HashiCorp vault signing from the ssh-proxy-agent library

Allows users to set a vault signing url and user principals through the edit menu and sign SSH keys via the provided HashiCorp Vault path and user principals.  These keys are automatically resigned and retained in the agent for the lifetime of the VAULT_TOKEN / Vaulted vault session.

