### PR TITLE
Prompt user for key generation when using key signing

### DIFF
--- a/menu/ssh_agent.go
+++ b/menu/ssh_agent.go
@@ -71,6 +71,13 @@ func (m *SSHKeyMenu) Handler() error {
 				m.Vault.SSHOptions = &vaulted.SSHOptions{}
 			}
 			m.Vault.SSHOptions.VaultSigningUrl = signingUrl
+
+			if signingUrl != "" && !m.Vault.SSHOptions.GenerateRSAKey {
+				generateKey, _ := interaction.ReadValue("Would you like to enable RSA key generation (y/n): ")
+				if generateKey == "y" {
+					m.Vault.SSHOptions.GenerateRSAKey = true
+				}
+			}
 		case "u", "users":
 			userPrincipals, err := interaction.ReadValue("HashiCorp Vault user principals (comma separated): ")
 			if err != nil {


### PR DESCRIPTION
When enabling SSH key signing in the edit menu we should encourage the user to enable key generation as well (if it is not already) as this improves the overall experience and adds some visibility to the SSH key generation option.