### PR TITLE
Add option to disable upstream SSH proxying

### DIFF
--- a/lib/session.go
+++ b/lib/session.go
@@ -155,6 +155,7 @@ func (s *Session) Spawn(cmd []string) (*int, error) {
 
 	vars := make(map[string]string)
 	sshAgent, err := proxyagent.SetupAgent(proxyagent.AgentConfig{
+		DisableProxy:    s.SSHOptions.DisableProxy,
 		GenerateRSAKey:  s.SSHOptions.GenerateRSAKey,
 		ValidPrincipals: s.SSHOptions.ValidPrincipals,
 		VaultSigningUrl: s.SSHOptions.VaultSigningUrl,
@@ -162,7 +163,10 @@ func (s *Session) Spawn(cmd []string) (*int, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.populateAgent(sshAgent)
+	err = s.populateAgent(sshAgent)
+	if err != nil {
+		return nil, err
+	}
 
 	server := proxyagent.NewServer(sshAgent)
 	err = server.Start()

--- a/lib/vault.go
+++ b/lib/vault.go
@@ -17,6 +17,7 @@ var (
 )
 
 type SSHOptions struct {
+	DisableProxy    bool     `json:"disable_proxy"`
 	GenerateRSAKey  bool     `json:"generate_rsa_key"`
 	ValidPrincipals []string `json:"valid_principals,omitempty"`
 	VaultSigningUrl string   `json:"vault_signing_url,omitempty"`

--- a/menu/ssh_agent.go
+++ b/menu/ssh_agent.go
@@ -31,6 +31,7 @@ func (m *SSHKeyMenu) Help() {
 	fmt.Println("g,generate - Generate Key")
 	fmt.Println("v          - HashiCorp Vault Signing URL")
 	fmt.Println("u,users    - HashiCorp Vault User Principals")
+	fmt.Println("e          - Expose External SSH Agent")
 	fmt.Println("?,help     - Help")
 	fmt.Println("b,back     - Back")
 	fmt.Println("q,quit     - Quit")
@@ -40,7 +41,7 @@ func (m *SSHKeyMenu) Handler() error {
 	for {
 		var err error
 		m.Printer()
-		input, err := interaction.ReadMenu("Edit ssh keys: [a,D,g,v,u,b]: ")
+		input, err := interaction.ReadMenu("Edit ssh keys: [a,D,g,v,u,e,b]: ")
 		if err != nil {
 			return err
 		}
@@ -91,6 +92,11 @@ func (m *SSHKeyMenu) Handler() error {
 			} else {
 				m.Vault.SSHOptions.ValidPrincipals = []string{}
 			}
+		case "e":
+			if m.Vault.SSHOptions == nil {
+				m.Vault.SSHOptions = &vaulted.SSHOptions{}
+			}
+			m.Vault.SSHOptions.DisableProxy = !m.Vault.SSHOptions.DisableProxy
 		case "b", "back":
 			return nil
 		case "q", "quit", "exit":
@@ -278,6 +284,9 @@ func (m *SSHKeyMenu) Printer() {
 				green.Printf("    User: ")
 				fmt.Printf("%s\n", m.Vault.SSHOptions.ValidPrincipals)
 			}
+
+			cyan.Print("\n  Expose external SSH agent: ")
+			fmt.Printf("%t\n", !m.Vault.SSHOptions.DisableProxy)
 		}
 	}
 }


### PR DESCRIPTION
adds the option to disable the upstream ssh agent when spawning a session proxy.  this allows users to insulate their session with only required keys in their ssh-agent.