### PR TITLE
Cache generated SSH key for session duration

### DIFF
--- a/lib/session.go
+++ b/lib/session.go
@@ -26,11 +26,12 @@ type Session struct {
 
 	ActiveRole string `json:"active_role,omitempty"`
 
-	AWSCreds   *AWSCredentials   `json:"aws_creds,omitempty"`
-	Role       string            `json:"role,omitempty"`
-	Vars       map[string]string `json:"vars,omitempty"`
-	SSHKeys    map[string]string `json:"ssh_keys,omitempty"`
-	SSHOptions *SSHOptions       `json:"ssh_options,omitempty"`
+	AWSCreds        *AWSCredentials   `json:"aws_creds,omitempty"`
+	GeneratedSSHKey string            `json:"generated_ssh_key,omitempty"`
+	Role            string            `json:"role,omitempty"`
+	Vars            map[string]string `json:"vars,omitempty"`
+	SSHKeys         map[string]string `json:"ssh_keys,omitempty"`
+	SSHOptions      *SSHOptions       `json:"ssh_options,omitempty"`
 }
 
 func (s *Session) Clone() *Session {
@@ -58,6 +59,10 @@ func (s *Session) Clone() *Session {
 		session.SSHOptions = s.SSHOptions
 	} else {
 		session.SSHOptions = &SSHOptions{}
+	}
+
+	if s.GeneratedSSHKey != "" {
+		session.GeneratedSSHKey = s.GeneratedSSHKey
 	}
 
 	return &session
@@ -156,7 +161,6 @@ func (s *Session) Spawn(cmd []string) (*int, error) {
 	vars := make(map[string]string)
 	sshAgent, err := proxyagent.SetupAgent(proxyagent.AgentConfig{
 		DisableProxy:    s.SSHOptions.DisableProxy,
-		GenerateRSAKey:  s.SSHOptions.GenerateRSAKey,
 		ValidPrincipals: s.SSHOptions.ValidPrincipals,
 		VaultSigningUrl: s.SSHOptions.VaultSigningUrl,
 	})
@@ -234,25 +238,37 @@ func (s *Session) Spawn(cmd []string) (*int, error) {
 func (s *Session) populateAgent(sshAgent agent.Agent) error {
 	// load ssh keys
 	for comment, key := range s.SSHKeys {
-		timeRemaining := s.Expiration.Sub(time.Now())
-		addedKey := agent.AddedKey{
-			Comment:      comment,
-			LifetimeSecs: uint32(timeRemaining.Seconds()),
-		}
-
-		var err error
-		addedKey.PrivateKey, err = ssh.ParseRawPrivateKey([]byte(key))
+		err := s.loadKeyIntoAgent(sshAgent, key, comment)
 		if err != nil {
 			return err
 		}
+	}
 
-		err = sshAgent.Add(addedKey)
+	// load generated ssh key if needed
+	if s.GeneratedSSHKey != "" {
+		err := s.loadKeyIntoAgent(sshAgent, s.GeneratedSSHKey, "ssh-proxy-agent-generated-key")
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (s *Session) loadKeyIntoAgent(sshAgent agent.Agent, key string, comment string) error {
+	timeRemaining := s.Expiration.Sub(time.Now())
+	addedKey := agent.AddedKey{
+		Comment:      comment,
+		LifetimeSecs: uint32(timeRemaining.Seconds()),
+	}
+
+	var err error
+	addedKey.PrivateKey, err = ssh.ParseRawPrivateKey([]byte(key))
+	if err != nil {
+		return err
+	}
+
+	return sshAgent.Add(addedKey)
 }
 
 func (s *Session) Variables() *Variables {

--- a/lib/session_cache.go
+++ b/lib/session_cache.go
@@ -95,6 +95,14 @@ func VaultSessionCacheKey(vault *Vault) string {
 		keyAttributes["ssh_key_"+key] = value
 	}
 
+	// we cannot compare the actual generated key, so instead we just
+	// want to confirm that if its existence matches the current vault
+	if vault.SSHOptions != nil && vault.SSHOptions.GenerateRSAKey {
+		keyAttributes["generated_key_exists"] = "true"
+	} else {
+		keyAttributes["generated_key_exists"] = "false"
+	}
+
 	// get a sorted list of the keys (that do not have blank values)
 	var keys []string
 	for key, value := range keyAttributes {

--- a/lib/session_cache_test.go
+++ b/lib/session_cache_test.go
@@ -30,6 +30,8 @@ var (
 		SSHKeys: map[string]string{
 			"SSH_TESTING": "ssh_testing",
 		},
+
+		SSHOptions: &vaulted.SSHOptions{},
 	}
 )
 

--- a/lib/store.go
+++ b/lib/store.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/miquella/ssh-proxy-agent/lib/proxyagent"
 	"github.com/miquella/xdg"
 	"golang.org/x/crypto/nacl/secretbox"
 )
@@ -263,6 +264,16 @@ func (s *store) CreateSession(v *Vault, name, password string) (*Session, error)
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	// create a fresh generated key if we are not using a cached session
+	if v.SSHOptions != nil && v.SSHOptions.GenerateRSAKey {
+		var keyPair *proxyagent.KeyPair
+		keyPair, err = proxyagent.GenerateRSAKeyPair()
+		if err != nil {
+			return nil, err
+		}
+		session.GeneratedSSHKey = keyPair.PrivateKey
 	}
 
 	// we ignore errors because the session is viable even if saving the cache fails

--- a/lib/vault.go
+++ b/lib/vault.go
@@ -3,6 +3,8 @@ package vaulted
 import (
 	"errors"
 	"time"
+
+	"github.com/miquella/ssh-proxy-agent/lib/proxyagent"
 )
 
 const (
@@ -73,13 +75,23 @@ func (v *Vault) newSession(name string, credsFunc func(duration time.Duration) (
 		}
 	}
 
+	var err error
 	// copy the vault ssh options to the session
 	if v.SSHOptions != nil {
 		s.SSHOptions = v.SSHOptions
+
+		// generate an SSH key for the session if necessary
+		if v.SSHOptions.GenerateRSAKey {
+			var keyPair *proxyagent.KeyPair
+			keyPair, err = proxyagent.GenerateRSAKeyPair()
+			if err != nil {
+				return nil, err
+			}
+			s.GeneratedSSHKey = keyPair.PrivateKey
+		}
 	}
 
 	if v.AWSKey.Valid() {
-		var err error
 		s.AWSCreds, err = credsFunc(duration)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
adds session caching for in-memory generated SSH keys

because the user experience is diminished when a generated key rotates every time they open a cached session we should look to cache the generated key with the session so that it only regenerates when the session changes.  this also saves time, as the key generation can take a few seconds.