### PR TITLE
Fix MFA auto-detection for non-standard partitions

### DIFF
--- a/menu/detect_mfa.go
+++ b/menu/detect_mfa.go
@@ -124,6 +124,10 @@ func (m *DetectMFAMenu) iamClient() (*iam.IAM, error) {
 		),
 	}
 
+	if m.Vault.AWSKey.Region != nil {
+		config.Region = aws.String(*m.Vault.AWSKey.Region)
+	}
+
 	s, err := session.NewSession(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In order for a key from a non-standard partition to work (e.g. GovCloud or China), the region must be properly configured.

Presently, the region is not configured for the MFA detection client, so detection always fails.