### PR TITLE
fix edit display of proxy without signing enabled

### DIFF
--- a/menu/ssh_agent.go
+++ b/menu/ssh_agent.go
@@ -284,9 +284,9 @@ func (m *SSHKeyMenu) Printer() {
 				green.Printf("    User(s): ")
 				fmt.Printf("%s\n", strings.Join(m.Vault.SSHOptions.ValidPrincipals, ", "))
 			}
-
-			cyan.Print("\n  Expose external SSH agent: ")
-			fmt.Printf("%t\n", !m.Vault.SSHOptions.DisableProxy)
 		}
+
+		cyan.Print("\n  Expose external SSH agent: ")
+		fmt.Printf("%t\n", !m.Vault.SSHOptions.DisableProxy)
 	}
 }


### PR DESCRIPTION
we were not displaying in the edit menu whether the external
agent was exposed or not unless SSH signing was enabled

now we do