### PR TITLE
Fix cloning session with SSHOptions

### DIFF
--- a/lib/session.go
+++ b/lib/session.go
@@ -56,7 +56,8 @@ func (s *Session) Clone() *Session {
 	}
 
 	if s.SSHOptions != nil {
-		session.SSHOptions = s.SSHOptions
+		sshOptions := *s.SSHOptions
+		session.SSHOptions = &sshOptions
 	} else {
 		session.SSHOptions = &SSHOptions{}
 	}


### PR DESCRIPTION
`(*Session).Clone()` incorrectly copied the reference to the old `SSHOptions` rather than cloning it as well.

This means that any modifications to the SSH options, whether through the old session or the new, would be manifested in the other session. This is clearly undesired behavior of a clone method, so we now duplicate the `SSHOptions` as well.