### PR TITLE
dont ignore explicitly empty signing users via CLI

### DIFF
--- a/session_generation.go
+++ b/session_generation.go
@@ -171,8 +171,12 @@ func updateVaultFromSSHOptions(vault *vaulted.Vault, options *SessionOptions) {
 	if len(vault.SSHOptions.ValidPrincipals) > 0 {
 		signingUsers = vault.SSHOptions.ValidPrincipals
 	}
-	if len(options.SigningUsers) > 0 {
-		signingUsers = options.SigningUsers
+	if options.SigningUsers != nil {
+		if len(options.SigningUsers) > 0 {
+			signingUsers = options.SigningUsers
+		} else {
+			signingUsers = []string{proxyagent.DefaultPrincipal()}
+		}
 	}
 	vault.SSHOptions.ValidPrincipals = signingUsers
 }


### PR DESCRIPTION
if the user explicitly sets the ssh users to empty via the CLI
(e.g. ssh-signing-users=) we should fall back to the default
signing users rather than ignoring or disabling the option