### PR TITLE
remove key generate prompt if keys exist

### DIFF
--- a/menu/ssh_agent.go
+++ b/menu/ssh_agent.go
@@ -73,7 +73,7 @@ func (m *SSHKeyMenu) Handler() error {
 			}
 			m.Vault.SSHOptions.VaultSigningUrl = signingUrl
 
-			if signingUrl != "" && !m.Vault.SSHOptions.GenerateRSAKey {
+			if signingUrl != "" && !m.Vault.SSHOptions.GenerateRSAKey && len(m.Vault.SSHKeys) == 0 {
 				generateKey, _ := interaction.ReadValue("Would you like to enable RSA key generation (y/n): ")
 				if generateKey == "y" {
 					m.Vault.SSHOptions.GenerateRSAKey = true


### PR DESCRIPTION
when a user adds an SSH key signing url we ask if they would like
to enable key generation if it is not already enabled.

we should not trigger this prompt if there are already keys loaded
into the vault as it created a confusing user flow when enabling
signing