### PR TITLE
also expose unsigned keys when signing is enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/miquella/ask v1.0.0
-	github.com/miquella/ssh-proxy-agent v0.5.0
+	github.com/miquella/ssh-proxy-agent v0.6.0
 	github.com/miquella/xdg v1.0.0
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/miquella/ssh-proxy-agent v0.4.0 h1:NWfoJwI0DyF/XEP0p70Bts6prFAAhkAyEx
 github.com/miquella/ssh-proxy-agent v0.4.0/go.mod h1:Kvgpc2dKPyKO2KadzUgBwPNICD8w87O8FSsmBxP6xrw=
 github.com/miquella/ssh-proxy-agent v0.5.0 h1:8LoO+sTULses3w6XvKmFFhq5MWh1vvyFa4J3zpCN9DA=
 github.com/miquella/ssh-proxy-agent v0.5.0/go.mod h1:+DYHUCWUps5cT7l5nA5pumD5ERpDCwTmO6aTzxVpyZI=
+github.com/miquella/ssh-proxy-agent v0.6.0 h1:mKMN2YJS70DTv2ZNKh2BezP9X6nJPJiCw9lwFkbvjKA=
+github.com/miquella/ssh-proxy-agent v0.6.0/go.mod h1:+DYHUCWUps5cT7l5nA5pumD5ERpDCwTmO6aTzxVpyZI=
 github.com/miquella/xdg v1.0.0 h1:MAuy6cGqJPs3evpBKzWGRV7r7RzVWXkcj218TaIdiwo=
 github.com/miquella/xdg v1.0.0/go.mod h1:g8uVrUbcx+7tDosTwHzv4LIHPbPFU9wVUklvpPZu04Q=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/lib/session.go
+++ b/lib/session.go
@@ -162,6 +162,7 @@ func (s *Session) Spawn(cmd []string) (*int, error) {
 	vars := make(map[string]string)
 	sshAgent, err := proxyagent.SetupAgent(proxyagent.AgentConfig{
 		DisableProxy:    s.SSHOptions.DisableProxy,
+		ExposeUnsigned:  true,
 		ValidPrincipals: s.SSHOptions.ValidPrincipals,
 		VaultSigningUrl: s.SSHOptions.VaultSigningUrl,
 	})


### PR DESCRIPTION
there are use cases where users will need to have access to the
unsigned versions of their keys even when signing is enabled, so
we are enabling the feature that both types of key will be
exposed to the signing agent

this requires bumping to a version of the proxy agent with https://github.com/ryan-norton/ssh-proxy-agent/commit/5ce8965632e3e6e38731e6a195b232cfbbf27c08 enabled