### PR TITLE
Adjust module path to account for major version

### DIFF
--- a/command.go
+++ b/command.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/miquella/vaulted/edit"
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/edit"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 var (

--- a/command_test.go
+++ b/command_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/miquella/vaulted/edit"
+	"github.com/miquella/vaulted/v3/edit"
 )
 
 type parseCase struct {

--- a/copy.go
+++ b/copy.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type Copy struct {

--- a/copy_test.go
+++ b/copy_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 func TestCopy(t *testing.T) {

--- a/dump.go
+++ b/dump.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type Dump struct {

--- a/dump_test.go
+++ b/dump_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 func TestDump(t *testing.T) {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/miquella/vaulted/lib"
-	"github.com/miquella/vaulted/menu"
+	"github.com/miquella/vaulted/v3/lib"
+	"github.com/miquella/vaulted/v3/menu"
 )
 
 var (

--- a/env.go
+++ b/env.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type Env struct {

--- a/env_test.go
+++ b/env_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/miquella/vaulted
+module github.com/miquella/vaulted/v3
 
 require (
 	github.com/aws/aws-sdk-go v1.29.2

--- a/help.go
+++ b/help.go
@@ -12,7 +12,7 @@ import (
 	"os/exec"
 	"path"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 var (

--- a/lib/legacy/legacy_store.go
+++ b/lib/legacy/legacy_store.go
@@ -1,7 +1,7 @@
 package legacy
 
 import (
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type LegacyStore interface {

--- a/lib/legacy/legacy_vault.go
+++ b/lib/legacy/legacy_vault.go
@@ -14,7 +14,7 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 const (

--- a/lib/legacy/legacy_vault_test.go
+++ b/lib/legacy/legacy_vault_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/miquella/vaulted/lib/legacy"
+	"github.com/miquella/vaulted/v3/lib/legacy"
 )
 
 const (

--- a/lib/session_cache_test.go
+++ b/lib/session_cache_test.go
@@ -3,7 +3,7 @@ package vaulted_test
 import (
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 var (

--- a/lib/store_test.go
+++ b/lib/store_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/miquella/xdg"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 const (

--- a/lib/sts_endpoint_resolver_test.go
+++ b/lib/sts_endpoint_resolver_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 var DefaultEndpoint = endpoints.ResolvedEndpoint{

--- a/list.go
+++ b/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type List struct {

--- a/list_test.go
+++ b/list_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 func TestList(t *testing.T) {

--- a/load.go
+++ b/load.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type Load struct {

--- a/load_test.go
+++ b/load_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 func TestLoad(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/miquella/vaulted/lib"
-	"github.com/miquella/vaulted/lib/legacy"
+	"github.com/miquella/vaulted/v3/lib"
+	"github.com/miquella/vaulted/v3/lib/legacy"
 )
 
 const (

--- a/main_test.go
+++ b/main_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/miquella/vaulted/lib"
-	"github.com/miquella/vaulted/lib/legacy"
+	"github.com/miquella/vaulted/v3/lib"
+	"github.com/miquella/vaulted/v3/lib/legacy"
 )
 
 func CaptureStdout(f func()) []byte {

--- a/menu/aws.go
+++ b/menu/aws.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/fatih/color"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 // AWSMenu The menu type for the AWS edit tree

--- a/menu/duration.go
+++ b/menu/duration.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type DurationMenu struct {

--- a/menu/import_credentials.go
+++ b/menu/import_credentials.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/fatih/color"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type ImportCredentialsMenu struct {

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 var (

--- a/menu/ssh_agent.go
+++ b/menu/ssh_agent.go
@@ -15,7 +15,7 @@ import (
 	"github.com/miquella/ask"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type SSHKeyMenu struct {

--- a/remove.go
+++ b/remove.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type Remove struct {

--- a/remove_test.go
+++ b/remove_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 func TestRemove(t *testing.T) {

--- a/session_generation.go
+++ b/session_generation.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/miquella/ssh-proxy-agent/lib/proxyagent"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 var (

--- a/spawn.go
+++ b/spawn.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/miquella/ask"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 type Spawn struct {

--- a/spawn_test.go
+++ b/spawn_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 func TestSpawn(t *testing.T) {

--- a/steward.go
+++ b/steward.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/miquella/ask"
 
-	"github.com/miquella/vaulted/lib"
-	"github.com/miquella/vaulted/lib/legacy"
+	"github.com/miquella/vaulted/v3/lib"
+	"github.com/miquella/vaulted/v3/lib/legacy"
 )
 
 func NewSteward() vaulted.Steward {

--- a/upgrade.go
+++ b/upgrade.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/miquella/vaulted/lib"
-	"github.com/miquella/vaulted/lib/legacy"
+	"github.com/miquella/vaulted/v3/lib"
+	"github.com/miquella/vaulted/v3/lib/legacy"
 )
 
 var (

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/miquella/vaulted/lib"
-	"github.com/miquella/vaulted/lib/legacy"
+	"github.com/miquella/vaulted/v3/lib"
+	"github.com/miquella/vaulted/v3/lib/legacy"
 )
 
 func TestUpgrade(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/miquella/vaulted/lib"
+	"github.com/miquella/vaulted/v3/lib"
 )
 
 const (


### PR DESCRIPTION
Go modules require that major versions have distinct import paths. This was missed for Vaulted v2, so in v3 we're correcting this.