### PR TITLE
support `/` inside of vault names

### DIFF
--- a/lib/vault_file.go
+++ b/lib/vault_file.go
@@ -50,13 +50,11 @@ func readVaultFile(name string) (*VaultFile, error) {
 }
 
 func writeVaultFile(name string, vaultFile *VaultFile) error {
-	pathname := xdg.DATA_HOME.Join("vaulted")
-	err := os.MkdirAll(pathname, 0700)
+	filename := xdg.DATA_HOME.Join(filepath.Join("vaulted", name))
+	err := os.MkdirAll(filepath.Dir(filename), 0700)
 	if err != nil {
 		return err
 	}
-
-	filename := xdg.DATA_HOME.Join(filepath.Join("vaulted", name))
 	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes #196 

not the best code of all time, for listing vaults (since i struggled of a way to think of filepath joining, without copying the string extra times? Though maybe this is more unreadable, but figured I'd at least push this up and can always change later.)

I went through some basic scenarios locally with a go built version:

```shell
$ ./vaulted create testing/test
Creating new vault 'testing/test'...

[...]

?=Help; q=Save and Quit; Ctrl+C=Abort
Edit AWS key [k,m,r,R,t,S,D,b]: q

Are you sure you wish to save and exit the vault? (y/n): y
Vault 'testing/test'
   New password: 
   Confirm password: 
Vault 'testing/test' successfully saved!
$ ./vaulted list
[...]
testing/test
[...]
$ ./vaulted cp testing/test test/a/very/big/test/lol
Vault 'testing/test'
   Password: 
Vault 'test/a/very/big/test/lol'
   New password: 
   Confirm password:
$ ./vaulted list
[...]
test/a/very/big/test/lol
testing/test
[...]
$ ./vaulted dump testing/test
Vault 'testing/test'
   Password: 
{
  "aws_key": {
    "id": "asdf",
    "secret": "asdf",
    "forgoTempCredGeneration": false
  }
} 
$ ./vaulted dump test/a/very/big/test/lol
Vault 'test/a/very/big/test/lol'
   Password: 
{
  "aws_key": {
    "id": "asdf",
    "secret": "asdf",
    "forgoTempCredGeneration": false
  }
} 
$ rm -rf /home/cynthia/.local/share/vaulted/testing/
$ rm -rf /home/cynthia/.local/share/vaulted/test/
$ ./vaulted dump test/a/very/big/test/lol
file does not exist
$ ./vaulted list
bs-root
cncf-envoy
tetrate-hub
tetrate/hub
```